### PR TITLE
Heroku deproy

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,9 @@ test:
 #
 production:
   <<: *default
-  database: toothmemo_production
-  username: toothmemo
-  password: <%= ENV['TOOTHMEMO_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  #database: toothmemo_production
+  #username: toothmemo
+  #password: <%= ENV['TOOTHMEMO_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/db/migrate/20200309060122_add_references_to_animals.rb
+++ b/db/migrate/20200309060122_add_references_to_animals.rb
@@ -1,6 +1,0 @@
-class AddReferencesToAnimals < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :animals, :breed, foreign_key: true
-
-  end
-end

--- a/db/migrate/20200312080435_rename_template_column_to_templates.rb
+++ b/db/migrate/20200312080435_rename_template_column_to_templates.rb
@@ -1,5 +1,0 @@
-class RenameTemplateColumnToTemplates < ActiveRecord::Migration[5.2]
-  def change
-    rename_column :templates, :template, :content
-  end
-end

--- a/db/migrate/20200312083930_change_templates_to_check_records.rb
+++ b/db/migrate/20200312083930_change_templates_to_check_records.rb
@@ -1,5 +1,0 @@
-class ChangeTemplatesToCheckRecords < ActiveRecord::Migration[5.2]
-  def change
-    rename_table :templates, :check_records
-  end
-end

--- a/db/migrate/20200312084040_change_posts_templates_to_posts_check_records.rb
+++ b/db/migrate/20200312084040_change_posts_templates_to_posts_check_records.rb
@@ -1,5 +1,0 @@
-class ChangePostsTemplatesToPostsCheckRecords < ActiveRecord::Migration[5.2]
-  def change
-    rename_table :posts_templates, :posts_check_records
-  end
-end

--- a/db/migrate/20200312103738_remove_index_from_animals.rb
+++ b/db/migrate/20200312103738_remove_index_from_animals.rb
@@ -1,7 +1,0 @@
-class RemoveIndexFromAnimals < ActiveRecord::Migration[5.2]
-  def change
-    remove_index :animals, :breed_id
-    remove_foreign_key :animals, :breeds
-    drop_table :breeds
-  end
-end

--- a/db/migrate/20200312104735_remove_index_of_temprate.rb
+++ b/db/migrate/20200312104735_remove_index_of_temprate.rb
@@ -1,8 +1,0 @@
-class RemoveIndexOfTemprate < ActiveRecord::Migration[5.2]
-  def change
-    remove_index :posts,:template_id
-    remove_index :posts_check_records, :template_id
-    remove_foreign_key :posts, :check_records
-    remove_foreign_key :posts_check_records, :check_records
-  end
-end

--- a/db/migrate/20200312105837_remove_column_breed_id_template_id.rb
+++ b/db/migrate/20200312105837_remove_column_breed_id_template_id.rb
@@ -1,7 +1,0 @@
-class RemoveColumnBreedIdTemplateId < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :animals, :breed_id, :bigint
-    remove_column :posts, :template_id, :bigint
-    remove_column :posts_check_records, :template_id, :bigint
-  end
-end

--- a/db/migrate/20200313032400_drop_table_to_check_records.rb
+++ b/db/migrate/20200313032400_drop_table_to_check_records.rb
@@ -1,7 +1,0 @@
-class DropTableToCheckRecords < ActiveRecord::Migration[5.2]
-  def change
-    remove_reference :posts_check_records, :post
-    drop_table :check_records
-    drop_table :posts_check_records
-  end
-end


### PR DESCRIPTION
migrationファイルが上から読み込まれると削除したモデル関連のファイルが不正になるので
削除

heroku用にファイルの変更